### PR TITLE
Make small dataset for recipeData to be used in unit tests

### DIFF
--- a/test/user-test.js
+++ b/test/user-test.js
@@ -1,7 +1,8 @@
 import { expect } from 'chai';
 
 import User from '../src/user.js';
-import recipeData from '../src/data/recipes.js'
+
+let recipeData;
 
 let user1;
 
@@ -21,7 +22,100 @@ describe('User', () => {
         'amount': 3
       }]
     );
-  });
+
+    recipeData = [
+      {
+   "name": "Loaded Chocolate Chip Pudding Cookie Cups",
+   "id": 595736,
+   "image": "https://spoonacular.com/recipeImages/595736-556x370.jpg",
+   "ingredients": [
+     {
+       "name": "all purpose flour",
+       "id": 20081,
+       "quantity": {
+         "amount": 1.5,
+         "unit": "c"
+       }
+     },
+     {
+       "name": "baking soda",
+       "id": 18372,
+       "quantity": {
+         "amount": 0.5,
+         "unit": "tsp"
+       }
+     },
+     {
+       "name": "egg",
+       "id": 1123,
+       "quantity": {
+         "amount": 1,
+         "unit": "large"
+       }
+     }
+   ],
+   "instructions": [
+     {
+       "number": 1,
+       "instruction": "In a large mixing bowl, whisk together the dry ingredients (flour, pudding mix, soda and salt). Set aside.In a large mixing bowl of a stand mixer, cream butter for 30 seconds. Gradually add granulated sugar and brown sugar and cream until light and fluffy."
+     },
+     {
+       "number": 2,
+       "instruction": "Add egg and vanilla and mix until combined."
+     },
+     {
+       "number": 3,
+       "instruction": "Add dry ingredients and mix on low just until incorporated. Stir in chocolate chips.Scoop the dough into 1,5 tablespoon size balls and place on a plate or sheet. Cover with saran wrap and chill at least 2 hours or overnight.When ready to bake, preheat oven to 350 degrees."
+     }
+   ],
+   "tags": [
+     "antipasti",
+     "starter"
+   ]
+ },
+ {
+   "name": "Maple Dijon Apple Cider Grilled Pork Chops",
+   "id": 678353,
+   "image": "https://spoonacular.com/recipeImages/678353-556x370.jpg",
+   "ingredients": [
+     {
+       "name": "apple cider",
+       "id": 1009016,
+       "quantity": {
+         "amount": 1.5,
+         "unit": "cups"
+       }
+     },
+     {
+       "name": "apples",
+       "id": 9003,
+       "quantity": {
+         "amount": 2,
+         "unit": ""
+       }
+     },
+     {
+       "name": "garlic",
+       "id": 11215,
+       "quantity": {
+         "amount": 1,
+         "unit": "clove"
+       }
+     }
+   ],
+   "instructions": [
+     {
+       "number": 1,
+       "instruction": "Season the pork chops with salt and pepper and grill or pan fry over medium high heat until cooked, about 3-5 minutes per side. (If grilling, baste the chops in the maple dijon apple cider sauce as you grill.)Meanwhile, mix the remaining ingredients except the apple slices, bring to a simmer and cook until the sauce thickens, about 2-5 minutes.Grill or saute the apple slices until just tender but still crisp.Toss the pork chops and apple slices in the maple dijon apple cider sauce and enjoy!"
+     }
+   ],
+   "tags": [
+     "lunch",
+     "main course",
+     "main dish"
+   ]
+ }];
+});
 
   it('Should be a function', () => {
     expect(User).to.be.a('function');
@@ -63,11 +157,11 @@ describe('User', () => {
 
   it('Should be able to add recipes to favoriteRecipes', () =>{
     user1.addToFavorites(recipeData[0]);
-    user1.addToFavorites(recipeData[2]);
+    user1.addToFavorites(recipeData[1]);
 
     expect(user1.favoriteRecipes.includes(recipeData[0])).to.eql(true);
-    expect(user1.favoriteRecipes.includes(recipeData[2])).to.eql(true);
-    expect(user1.favoriteRecipes).to.deep.eql([recipeData[0], recipeData[2]]);
+    expect(user1.favoriteRecipes.includes(recipeData[1])).to.eql(true);
+    expect(user1.favoriteRecipes).to.deep.eql([recipeData[0], recipeData[1]]);
   });
 
   it('Should be able to remove recipes from favoriteRecipes', () =>{
@@ -143,8 +237,8 @@ describe('User', () => {
 
   it('Should be able to add recipes to recipesToCook', () => {
     user1.addToRecipesToCook(recipeData[1]);
-    user1.addToRecipesToCook(recipeData[3]);
+    user1.addToRecipesToCook(recipeData[0]);
 
-    expect(user1.recipesToCook).to.deep.eql([recipeData[1], recipeData[3]]);
+    expect(user1.recipesToCook).to.deep.eql([recipeData[1], recipeData[0]]);
   });
 });


### PR DESCRIPTION
## Description

+ This PR adds a sample dataset to `user-test.js`, which is called `recipeData`.  The length of this `recipeData` array is 2.  Both recipe objects within the array are referenced in various unit tests.

+ Removed the import from the top of the file, which imported `recipeData` from the `recipes.js` file in the `data directory`.

## Affected areas of application

+ Only `user-test.js` is affected.  All tests are the same except for those that utilized `recipeData[2]` or `recipeData[3]`, which currently don't exist in the small dataset.

## How Has This Been Tested?

+ Tested with `npm test` in the terminal

## Relevant Tickets

n/a

## Screenshots

n/a