### PR TITLE
Add header, title, and search elements to mimic main page structure

### DIFF
--- a/src/pantry.html
+++ b/src/pantry.html
@@ -7,7 +7,34 @@
     <link rel="stylesheet" href="./styles.css">
   </head>
   <body>
-    <h1 class="my-pantry-title">My Pantry</h1>
-
+    <header class='main-header'>
+      <div class="wrapper">
+        <img class="hamburger-menu" src="./images/hamburger-icon.png" alt="hamburger icon serving as menu button">
+        <img class="x-menu hidden" src="./images/x-icon.png" alt="x icon to be clicked when you are done viewing the menu options">
+      </div>
+      <h1 class="header-title">What's Cookin'?</h1>
+      <h1 class="open-menu-title hidden">Menu</h1>
+      <div class="spacer"></div>
+    </header>
+    <section class="open-menu-selections hidden">
+      <article class="menu-my-pantry menu-selection hidden">
+        <h3 class="menu-my-pantry-title">My Pantry</h2>
+      </article>
+      <article class="menu-my-upcoming-recipes menu-selection hidden">
+        <h3 class="menu-my-upcoming-recipes-title">My Upcoming Recipes</h2>
+      </article>
+      <article class="menu-favorites menu-selection hidden">
+        <h3 class="menu-favorites-title">Favorites</h2>
+      </article>
+    </section>
+    <section class="all-recipes-and-search">
+      <h1 class="all-recipes-title">My Pantry</h1>
+      <section class="search-recipes">
+        <div class="wrapper">
+          <img class="search-icon" src="./images/search-icon.png" alt="search icon to the left of the search recipes input">
+          <input class="search-recipes-input" type="text" placeholder="search recipes">
+        </div>
+      </section>
+    </section>
   </body>
 </html>


### PR DESCRIPTION
## Description

+ Added `pantry.html` with same structure as `index.html`
+ Same structure includes header and search feature
+ Show `My Pantry` above search field 
+ This only has 1 commit, so not many changes have been made.  Mostly pushing this up so that it can be worked on by others.

## Affected areas of application

+ `pantry.html`

## How Has This Been Tested?

+ Opened in the browser, see screenshot below

## Relevant Tickets

+ N/A

## Screenshots

![Screen Shot 2020-09-10 at 8 14 51 PM](https://user-images.githubusercontent.com/62262404/92843774-584e4f00-f3a2-11ea-8d2d-a72789aadf11.png)
