### PR TITLE
Spies round2 ng

### DIFF
--- a/test/domUpdates-test.js
+++ b/test/domUpdates-test.js
@@ -1,5 +1,53 @@
+const chai = require('chai');
 import {expect} from 'chai';
-import domUpdates from '../src/domUpdates';
 const spies = require('chai-spies');
+
+chai.use(spies);
+
+describe('domUpdates spies', () => {
+  beforeEach(() => {
+    global.domUpdates = {};
+    chai.spy.on(domUpdates, ['displayAllRecipes', 'greetUser', 'displayFavorites', 'showRecipePopup'], () => { });
+  });
+
+  afterEach(() => {
+    chai.spy.restore(domUpdates)
+  });
+  
+  it('should display all recipes on load', () => {
+    let recipes = [];
+    let currentUser = 'Taylor';
+
+    domUpdates.displayAllRecipes(recipes, currentUser);
+
+    expect(domUpdates.displayAllRecipes).to.have.been.called(1);
+    expect(domUpdates.displayAllRecipes).to.have.been.called.with(recipes);
+    expect(domUpdates.displayAllRecipes).to.have.been.called.with(currentUser);
+  });
+  
+  it('should greet a new user on load', () => {
+    let user = 'Caleb';
+
+    domUpdates.greetUser(user);
+
+    expect(domUpdates.greetUser).to.have.been.called(1);
+    expect(domUpdates.greetUser).to.have.been.called.with(user);
+  });
+  
+  it('should display favorites when favorites is clicked on menu', () => {
+    let favorites = [];
+
+    domUpdates.displayFavorites(favorites);
+
+    expect(domUpdates.displayFavorites).to.have.been.called(1);
+    expect(domUpdates.displayFavorites).to.have.been.called.with(favorites);
+  });
+
+  it('should show recipe popup when recipe image is clicked', () => {
+    domUpdates.showRecipePopup()
+    expect(domUpdates.showRecipePopup).to.have.been.called(1);
+  });
+});
+
 
 

--- a/test/recipe-test.js
+++ b/test/recipe-test.js
@@ -103,7 +103,7 @@ describe('Recipe', () => {
 
   it('Should be able to calculate the cost of its ingredients', () => {
     // console.log(ingredientsData);
-    expect(recipe.calculateCost()).to.equal(2226);
+    expect(recipe.calculateCost()).to.equal(22.26);
   });
   it('Should be able to return recipe instructions ', () => {
     expect(recipe.returnInstructions()).to.deep.equal(


### PR DESCRIPTION
## Description

This PR includes a `domUpdates-test.js` that handles all `chai spies`.  We are testing the mock `domUpdates` empty object and four of its methods to mimic actual DOM functionality.

domUpdates.method:

+ displayAllRecipes
+ greetUser
+ displayFavorites
+ showRecipePopup

This PR also changes an expected result in `recipe-test.js` because the original test was calculating the cost in cents, but we found it would be easier for the user to see the cost in dollars.  That result needed to be updated to reflect desired improvements to the UX.

## Affected areas of application

+ `domUpdates-test.js`
+ `recipe-test.js`

## How Has This Been Tested?

These 4 tests have been failed, then passed using TDD's red-green strategy.

## Relevant Tickets

Closes #33 
Closes #34 

**Need to work on #36 in future iterations**

## Screenshots

N/A